### PR TITLE
Allow capture of payments when receiving a shipnotify notification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Spree.config do |config|
   # Turn on/off SSL requirepments for testing and development purposes
   config.shipstation_ssl_encrypted = !Rails.env.development?
 
+  # Captures payment when ShipStation notifies a shipping label creation, defaults to false
+  config.shipstation_capture_at_notification = false
 
   # Spree::Core related configuration
   # Both of these Spree::Core configuration options will affect which shipment records
@@ -107,11 +109,20 @@ Shipped                  | shipped            | shipped
 Cancelled                | cancelled          | cancelled
 On-Hold                  | on-hold            | pending (won't appear in API response)
 
+### Payment Capture
+
+By default the shipments exported are only the ones that have the state of `ready`, for Spree that means
+that the shipment has backordered inventory units and the order is paid for. By setting
+`require_payment_to_ship` to `false` and `shipstation_capture_at_notification` to `true`
+this extension will export shipments that are in the state of `pending` and will
+try to capture payments when a shipnotify notification is received.
+
 ## Caveats
 
 1. Removed [#send_shipped_email](https://github.com/DynamoMTL/spree_shipstation/blob/master/app/models/spree/shipment_decorator.rb#L9), which was previously available in `spree_shipstation`
 2. If you change the shipping method of an order in ShipStation, the change will not be reflected in Spree and the tracking link might not work properly.
 3. Removed the ability to use `Spree::Order.number` as the ShipStation order number. We now use `Spree::Shipment.number`. This was previously available in `spree_shipstation`
+4. When capture of payments is enabled any error will prevent the update of the tracking number.
 
 ## Testing
 

--- a/app/controllers/spree/shipstation_controller.rb
+++ b/app/controllers/spree/shipstation_controller.rb
@@ -10,7 +10,9 @@ module Spree
     protect_from_forgery with: :null_session, only: [:shipnotify]
 
     def export
-      @shipments = Spree::Shipment.between(date_param(:start_date), date_param(:end_date))
+      @shipments = Spree::Shipment.exportable
+                                  .between(date_param(:start_date),
+                                           date_param(:end_date))
                                   .page(params[:page])
                                   .per(50)
 

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -1,5 +1,9 @@
 Spree::Shipment.class_eval do
-  scope :exportable, -> { joins(:order).where('spree_shipments.state != ?', 'pending') }
+  def self.exportable
+    query = joins(:order).where(spree_orders: { state: 'complete' })
+    query = query.where.not(spree_shipments: { state: 'pending' }) if Spree::Config.require_payment_to_ship
+    query
+  end
 
   def self.between(from, to)
     joins(:order).where(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,3 +2,4 @@
 en:
   shipment_not_found: Shipment %{number} was not found
   import_tracking_error: "Tracking number cannot be imported. Error: %{error}"
+  capture_payment_error: "Error in capture of payment for order %{number}. Error: %{error}"

--- a/lib/solidus_shipstation/engine.rb
+++ b/lib/solidus_shipstation/engine.rb
@@ -16,6 +16,7 @@ module SolidusShipstation
         preference :shipstation_password,     :string
         preference :shipstation_weight_units, :string
         preference :shipstation_ssl_encrypted, :boolean, default: true
+        preference :shipstation_capture_at_notification, :boolean, default: false
       end
     end
 

--- a/lib/spree/shipment_notice.rb
+++ b/lib/spree/shipment_notice.rb
@@ -10,25 +10,57 @@ module Spree
     end
 
     def apply
-      locate ? update : not_found
+      find_shipment
+
+      unless shipment
+        log_not_found
+        return false
+      end
+
+      unless capture_payments!
+        log_not_paid
+        return false
+      end
+
+      ship_it!
     rescue => e
       handle_error(e)
     end
 
     private
 
+    def capture_payments!
+      order = shipment.order
+      return true if order.paid?
+
+      # We try to capture payments if flag is set
+      if Spree::Config.shipstation_capture_at_notification
+        process_payments!(order)
+      else
+        false
+      end
+    end
+
+    def process_payments!(order)
+      uncaptured_payments = order.payments.select(&:pending)
+      uncaptured_payments.each(&:capture!)
+    rescue Core::GatewayError => e
+      order.errors.add(:base, e.message) and return false
+    end
+
     # TODO: add documentation
     # => <Shipment>
-    def locate
+    def find_shipment
       @shipment = Spree::Shipment.find_by(number: number)
     end
 
     # TODO: add documentation
     # => true
-    def update
+    def ship_it!
       shipment.update_attribute(:tracking, tracking)
 
       unless shipment.shipped?
+        shipment.reload.ready! if shipment.pending?
         shipment.reload.ship!
         shipment.touch :shipped_at
         shipment.order.update!
@@ -37,11 +69,16 @@ module Spree
       true
     end
 
-    def not_found
+    def log_not_found
       @error = I18n.t(:shipment_not_found, number: number)
       Rails.logger.error(@error)
+    end
 
-      false
+    def log_not_paid
+      @error = I18n.t(:capture_payment_error,
+                      number: number,
+                      error: shipment.order.errors.full_messages.join(' '))
+      Rails.logger.error(@error)
     end
 
     def handle_error(error)

--- a/solidus_shipstation.gemspec
+++ b/solidus_shipstation.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-xsd'
+  s.add_development_dependency 'simplecov'
 end

--- a/spec/controllers/spree/shipstation_controller_spec.rb
+++ b/spec/controllers/spree/shipstation_controller_spec.rb
@@ -6,7 +6,8 @@ describe Spree::ShipstationController, type: :controller do
 
   before do
     Spree::Config.shipstation_ssl_encrypted = false # disable SSL for testing
-    described_class.stub(check_authorization: false, spree_current_user: FactoryGirl.create(:user))
+    allow(described_class).to receive(:check_authorization).and_return(false)
+    allow(described_class).to receive(:spree_current_user).and_return(FactoryGirl.create(:user))
     @request.env['HTTP_ACCEPT'] = 'application/xml'
   end
 
@@ -16,8 +17,8 @@ describe Spree::ShipstationController, type: :controller do
 
     describe '#export' do
       let(:schema) { 'spec/fixtures/shipstation_xml_schema.xsd' }
-      let(:order) { create(:order, completed_at: Time.now.utc) }
-      let!(:shipments) { create(:shipment, order: order) }
+      let(:order) { create(:order, state: 'complete', completed_at: Time.now.utc) }
+      let!(:shipments) { create(:shipment, state: 'ready', order: order) }
       let(:params) do
         {
           start_date: '01/01/2016 00:00',
@@ -44,7 +45,7 @@ describe Spree::ShipstationController, type: :controller do
       #   which might not reflect reality in practice
       let(:order_number) { 'ABC123' }
       let(:tracking_number) { '123456' }
-      let(:order) { create(:order) }
+      let(:order) { create(:order, payment_state: 'paid') }
       let(:address) { create(:address) }
       let!(:shipment) { create(:shipment, tracking: nil, number: order_number, order: order, address: address) }
       let!(:inventory_unit) { create(:inventory_unit, order: order, shipment: shipment) }

--- a/spec/lib/solidus_shipstation/engine_spec.rb
+++ b/spec/lib/solidus_shipstation/engine_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe SolidusShipstation::Engine do
       expect(Spree::Config).to respond_to(:shipstation_password)
       expect(Spree::Config).to respond_to(:shipstation_weight_units)
       expect(Spree::Config).to respond_to(:shipstation_ssl_encrypted)
+      expect(Spree::Config).to respond_to(:shipstation_capture_at_notification)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,16 @@
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
+SimpleCov.start do
+  add_filter 'spec/dummy'
+  add_group 'Controllers', 'app/controllers'
+  add_group 'Helpers', 'app/helpers'
+  add_group 'Mailers', 'app/mailers'
+  add_group 'Models', 'app/models'
+  add_group 'Views', 'app/views'
+  add_group 'Libraries', 'lib'
+end
+
 # Configure Rails Environment
 ENV['RAILS_ENV'] = 'test'
 


### PR DESCRIPTION
This PR does two things:

* Uses Spree::Config.require_payment_to_ship to decide which shipments to export.
* Adds Spree::Config.shipstation_capture_at_notification flag to enable capture of payments when we receive a notification of the creation of a shipment label.

Work for https://boomerdigital.atlassian.net/browse/TEES-32