### PR TITLE
Change logic of export and refactor tests

### DIFF
--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -1,7 +1,7 @@
 Spree::Shipment.class_eval do
   def self.exportable
-    query = joins(:order).where(spree_orders: { state: 'complete' })
-    query = query.where.not(spree_shipments: { state: 'pending' }) if Spree::Config.require_payment_to_ship
+    query = joins(:order).merge(Spree::Order.complete)
+    query = query.where.not(spree_shipments: { state: 'pending' }) if !Spree::Config.shipstation_capture_at_notification
     query
   end
 

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -1,7 +1,7 @@
 Spree::Shipment.class_eval do
   def self.exportable
-    query = joins(:order).merge(Spree::Order.complete)
-    query = query.where.not(spree_shipments: { state: 'pending' }) if !Spree::Config.shipstation_capture_at_notification
+    query = joins(:order).merge(Spree::Order.complete).where.not(spree_shipments: { state: 'canceled' })
+    query = query.ready unless Spree::Config.shipstation_capture_at_notification
     query
   end
 

--- a/lib/spree/shipment_notice.rb
+++ b/lib/spree/shipment_notice.rb
@@ -42,8 +42,7 @@ module Spree
     end
 
     def process_payments!(order)
-      uncaptured_payments = order.payments.pending
-      uncaptured_payments.each(&:capture!)
+      order.payments.pending.each(&:capture!)
     rescue Core::GatewayError => e
       order.errors.add(:base, e.message) and return false
     end

--- a/lib/spree/shipment_notice.rb
+++ b/lib/spree/shipment_notice.rb
@@ -42,7 +42,7 @@ module Spree
     end
 
     def process_payments!(order)
-      uncaptured_payments = order.payments.select(&:pending)
+      uncaptured_payments = order.payments.pending
       uncaptured_payments.each(&:capture!)
     rescue Core::GatewayError => e
       order.errors.add(:base, e.message) and return false
@@ -60,7 +60,6 @@ module Spree
       shipment.update_attribute(:tracking, tracking)
 
       unless shipment.shipped?
-        shipment.reload.ready! if shipment.pending?
         shipment.reload.ship!
         shipment.touch :shipped_at
         shipment.order.update!

--- a/spec/lib/spree/shipment_notice_spec.rb
+++ b/spec/lib/spree/shipment_notice_spec.rb
@@ -16,7 +16,7 @@ describe Spree::ShipmentNotice do
 
     context 'successful capture' do
       it 'payments are completed' do
-        order = FactoryGirl.create(:completed_order_with_pending_payment)
+        order = create(:completed_order_with_pending_payment)
         notice = define_shipment_notice(order)
         expect(notice.apply).to eq(true)
 
@@ -32,7 +32,7 @@ describe Spree::ShipmentNotice do
 
     context 'capture fails' do
       it "doesn't ship the shipment" do
-        order = FactoryGirl.create(:completed_order_with_pending_payment)
+        order = create(:completed_order_with_pending_payment)
         notice = define_shipment_notice(order)
 
         expect_any_instance_of(Payment).to receive(:capture!).and_raise(Spree::Core::GatewayError)
@@ -56,7 +56,7 @@ describe Spree::ShipmentNotice do
 
     context 'order is not paid' do
       it "doesn't ship the shipment" do
-        order = FactoryGirl.create(:completed_order_with_pending_payment)
+        order = create(:completed_order_with_pending_payment)
         notice = define_shipment_notice(order)
 
         expect(notice.apply).to eq(false)
@@ -133,7 +133,7 @@ describe Spree::ShipmentNotice do
   context 'shipment already shipped' do
     it 'updates #tracking and returns true' do
       tracking_number = 'ZN10110'
-      order = FactoryGirl.create(:shipped_order)
+      order = create(:shipped_order)
       notice = define_shipment_notice(order, tracking_number)
 
       expect(notice.apply).to eq(true)
@@ -141,7 +141,7 @@ describe Spree::ShipmentNotice do
     end
 
     it 'does not update #state' do
-      order = FactoryGirl.create(:shipped_order)
+      order = create(:shipped_order)
       notice = define_shipment_notice(order)
       expect { notice.apply }.to_not change { order.shipments.first.state }
     end

--- a/spec/lib/spree/shipment_notice_spec.rb
+++ b/spec/lib/spree/shipment_notice_spec.rb
@@ -39,7 +39,7 @@ describe Spree::ShipmentNotice do
         expect_any_instance_of(Payment).to receive(:capture!).and_raise(Spree::Core::GatewayError)
       end
 
-      it 'shipment is not ship' do
+      it "doesn't ship the shipment" do
         expect(notice.apply).to eq(false)
         expect(shipment.reload).to_not be_shipped
         expect(payment.reload).to_not be_completed

--- a/spec/lib/spree/shipment_notice_spec.rb
+++ b/spec/lib/spree/shipment_notice_spec.rb
@@ -3,20 +3,13 @@ require 'spec_helper'
 include Spree
 
 describe Spree::ShipmentNotice do
-  let(:order_number) { 'S12345' }
-  let(:tracking_number) { '1Z1231234' }
-  let(:notice) do
-    ShipmentNotice.new(order_number:    order_number,
-                       tracking_number: tracking_number)
-  end
-
-  context 'capture at notification is active' do
+  context 'capture at notification is true' do
     let(:order) { FactoryGirl.create(:completed_order_with_pending_payment) }
     let(:payment) { order.payments.first }
     let(:shipment) { order.shipments.first }
     let(:notice) do
       ShipmentNotice.new(order_number:    shipment.number,
-                         tracking_number: tracking_number)
+                         tracking_number: '1Z1231234')
     end
 
     before do
@@ -35,11 +28,8 @@ describe Spree::ShipmentNotice do
     end
 
     context 'capture fails' do
-      before do
-        expect_any_instance_of(Payment).to receive(:capture!).and_raise(Spree::Core::GatewayError)
-      end
-
       it "doesn't ship the shipment" do
+        expect_any_instance_of(Payment).to receive(:capture!).and_raise(Spree::Core::GatewayError)
         expect(notice.apply).to eq(false)
         expect(shipment.reload).to_not be_shipped
         expect(payment.reload).to_not be_completed
@@ -48,11 +38,39 @@ describe Spree::ShipmentNotice do
     end
   end
 
-  context '#apply' do
-    context 'shipment found' do
-      let(:order) { instance_double(Order, paid?: true) }
-      let(:shipment) { instance_double(Shipment, order: order, shipped?: false, pending?: false) }
+  context 'capture at notification is false' do
+    before do
+      Spree::Config.shipstation_capture_at_notification = false
+    end
 
+    context 'order is not paid' do
+      let(:order) { FactoryGirl.create(:completed_order_with_pending_payment) }
+      let(:shipment) { order.shipments.first }
+      let(:notice) do
+        ShipmentNotice.new(order_number: shipment.number,
+                           tracking_number: '1Z1231234')
+      end
+
+      it "doesn't ship the shipment" do
+        expect(notice.apply).to eq(false)
+        expect(shipment.reload).to_not be_shipped
+        expect(order.reload).to_not be_paid
+        expect(notice.error).to be_present
+      end
+    end
+  end
+
+  context '#apply' do
+    let(:order_number) { 'S12345' }
+    let(:tracking_number) { '1Z1231234' }
+    let(:order) { instance_double(Order, paid?: true) }
+    let(:shipment) { instance_double(Shipment, order: order, shipped?: false, pending?: false) }
+    let(:notice) do
+      ShipmentNotice.new(order_number:    order_number,
+                         tracking_number: tracking_number)
+    end
+
+    context 'shipment found' do
       before do
         expect(Shipment).to receive(:find_by).with(number: order_number).and_return(shipment)
       end
@@ -84,25 +102,6 @@ describe Spree::ShipmentNotice do
           expect(notice.error).to be_present
         end
       end
-
-      context 'order is not paid' do
-        before do
-          expect(order).to receive(:paid?).and_return(false)
-        end
-
-        context 'capture at notification is not active' do
-          before do
-            Spree::Config.shipstation_capture_at_notification = false
-          end
-
-          it 'payments are not captured' do
-            expect(notice).to_not receive(:process_payments!)
-            expect(order).to receive_message_chain(:errors, :full_messages).and_return(["woops"])
-            expect(notice.apply).to eq(false)
-            expect(notice.error).to be_present
-          end
-        end
-      end
     end
 
     context 'shipment not found' do
@@ -116,23 +115,24 @@ describe Spree::ShipmentNotice do
         expect(notice.error).to be_present
       end
     end
+  end
 
-    context 'shipment already shipped' do
-      let(:order) { FactoryGirl.create(:order_ready_to_ship) }
-      let(:shipment) { order.shipments.first }
+  context 'shipment already shipped' do
+    let(:order) { FactoryGirl.create(:order_ready_to_ship) }
+    let(:shipment) { order.shipments.first }
+    let(:tracking_number) { '1Z1231234' }
+    let(:notice) do
+      ShipmentNotice.new(order_number:    shipment.number,
+                         tracking_number: tracking_number)
+    end
 
-      before do
-        shipment.update_attribute(:number, order_number)
-      end
+    it 'updates #tracking and returns true' do
+      expect(notice.apply).to eq(true)
+      expect(shipment.reload.tracking).to eq(tracking_number)
+    end
 
-      it 'updates #tracking and returns true' do
-        expect(notice.apply).to eq(true)
-        expect(shipment.reload.tracking).to eq(tracking_number)
-      end
-
-      it 'does not update #state' do
-        expect { notice.apply }.to_not change { shipment.state }
-      end
+    it 'does not update #state' do
+      expect { notice.apply }.to_not change { shipment.state }
     end
   end
 end

--- a/spec/lib/spree/shipment_notice_spec.rb
+++ b/spec/lib/spree/shipment_notice_spec.rb
@@ -26,7 +26,6 @@ describe Spree::ShipmentNotice do
     end
 
     context 'successful capture' do
-
       it 'payments are completed' do
         expect(notice.apply).to eq(true)
         expect(shipment.reload).to be_shipped

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -43,7 +43,7 @@ describe Spree::Shipment do
 
     describe '.exportable' do
       def create_complete_order
-        FactoryGirl.create(:order, state: 'complete')
+        FactoryGirl.create(:order, state: 'complete', completed_at: Time.now)
       end
 
       let!(:incomplete_order) { create(:order, state: 'confirm') }
@@ -58,8 +58,8 @@ describe Spree::Shipment do
 
       let(:query) { Spree::Shipment.exportable }
 
-      context 'given we require payment to ship' do
-        before { Spree::Config.require_payment_to_ship = true }
+      context 'given capture at notification is inactive' do
+        before { Spree::Config.shipstation_capture_at_notification = false }
         it 'should have the expected shipment instances', :aggregate_failures do
           expect(query.count).to eq(2)
           expect(query).to eq([ready, shipped])
@@ -68,8 +68,8 @@ describe Spree::Shipment do
         end
       end
 
-      context 'given we only require a complete order to ship' do
-        before { Spree::Config.require_payment_to_ship = false }
+      context 'given capture at notification is active' do
+        before { Spree::Config.shipstation_capture_at_notification = true }
         it 'should have the expected shipment instances', :aggregate_failures do
           expect(query.count).to eq(3)
           expect(query).to eq([pending, ready, shipped])

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -55,14 +55,16 @@ describe Spree::Shipment do
                                        order: create_complete_order) }
       let!(:shipped) { create_shipment(state: 'shipped',
                                        order: create_complete_order) }
+      let!(:canceled) { create_shipment(state: 'canceled',
+                                        order: create_complete_order) }
 
       let(:query) { Spree::Shipment.exportable }
 
       context 'given capture at notification is inactive' do
         before { Spree::Config.shipstation_capture_at_notification = false }
         it 'should have the expected shipment instances', :aggregate_failures do
-          expect(query.count).to eq(2)
-          expect(query).to eq([ready, shipped])
+          expect(query.count).to eq(1)
+          expect(query).to eq([ready])
           expect(query).to_not include(pending)
           expect(query).to_not include(incomplete)
         end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -60,7 +60,7 @@ describe Spree::Shipment do
 
       let(:query) { Spree::Shipment.exportable }
 
-      context 'given capture at notification is inactive' do
+      context 'given capture at notification is false' do
         before { Spree::Config.shipstation_capture_at_notification = false }
         it 'should have the expected shipment instances', :aggregate_failures do
           expect(query.count).to eq(1)
@@ -70,7 +70,7 @@ describe Spree::Shipment do
         end
       end
 
-      context 'given capture at notification is active' do
+      context 'given capture at notification is true' do
         before { Spree::Config.shipstation_capture_at_notification = true }
         it 'should have the expected shipment instances', :aggregate_failures do
           expect(query.count).to eq(3)


### PR DESCRIPTION
Default logic is to export every completed order with shipment status that is not `pending`.

If the preference `Spree::Config. shipstation_capture_at_notification` is true then we export
all completed orders without regard of their shipment status, and we capture the
payment for the orders that are still unpaid. 