### PR TITLE
Allowing gem to run against solidus 2.0 (rails 5.0)

### DIFF
--- a/Note-to-boomerdigital-git-admin
+++ b/Note-to-boomerdigital-git-admin
@@ -1,0 +1,5 @@
+Hello there
+
+The original fork https://github.com/stephen-puiszis/solidus_shipstation is no longer maintained and is pointing to you. Wouldn't it make sense for you to enable new issues to be opened against your fork? 
+
+

--- a/solidus_shipstation.gemspec
+++ b/solidus_shipstation.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'solidus_core', ' >= 1.1', '< 2.0'
+  s.add_dependency 'solidus_core', '>= 1.1', '< 3'
 
   s.add_development_dependency 'solidus_auth_devise'
   s.add_development_dependency 'capybara', '~> 2.2'


### PR DESCRIPTION
Solidus 2.0 is identical to solidus 1.4 except that it runs on rails 5. 

Credits to acreilly for the change.