### PR TITLE
Supporting Solidus 2.3 and rails 5.1

### DIFF
--- a/lib/spree/basic_ssl_authentication.rb
+++ b/lib/spree/basic_ssl_authentication.rb
@@ -6,7 +6,7 @@ module Spree
 
     included do
       force_ssl if: :ssl_configured?
-      before_filter :authenticate
+      before_action :authenticate
     end
 
     protected

--- a/solidus_shipstation.gemspec
+++ b/solidus_shipstation.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'solidus_auth_devise'
   s.add_development_dependency 'capybara', '~> 2.2'
-  s.add_development_dependency 'coffee-rails', '~> 4.1.1'
+  s.add_development_dependency 'coffee-rails', '>= 4.1'
   s.add_development_dependency 'factory_girl'
   s.add_development_dependency 'factory_girl_rails'
   s.add_development_dependency 'database_cleaner'


### PR DESCRIPTION
Solidus 2.3 supports (or requires?) rails 5.1

This change makes solidus_shipstation work with rails 5.1