### PR TITLE
Using shipment manifest instead of line_items to handle item exchange

### DIFF
--- a/app/views/spree/shipstation/export.xml.builder
+++ b/app/views/spree/shipstation/export.xml.builder
@@ -29,7 +29,7 @@ xml.Orders(pages: (@shipments.total_count/50.0).ceil) {
         Spree::ExportHelper.address(xml, order, :ship)
       }
       xml.Items {
-        shipment.line_items.each do |line|
+        shipment.manifest.each do |line|
           variant = line.variant
           xml.Item {
             xml.SKU         variant.sku

--- a/app/views/spree/shipstation/export.xml.builder
+++ b/app/views/spree/shipstation/export.xml.builder
@@ -29,16 +29,16 @@ xml.Orders(pages: (@shipments.total_count/50.0).ceil) {
         Spree::ExportHelper.address(xml, order, :ship)
       }
       xml.Items {
-        shipment.manifest.each do |line|
-          variant = line.variant
+        shipment.manifest.each do |item|
+          variant = item.variant
           xml.Item {
             xml.SKU         variant.sku
             xml.Name        [variant.product.name, variant.options_text].join(' ')
             xml.ImageUrl    variant.images.first.try(:attachment).try(:url)
             xml.Weight      variant.weight.to_f
             xml.WeightUnits Spree::Config.shipstation_weight_units
-            xml.Quantity    line.quantity
-            xml.UnitPrice   line.price
+            xml.Quantity    item.quantity
+            xml.UnitPrice   item.line_item.price
 
             if variant.option_values.present?
               xml.Options {


### PR DESCRIPTION
I modified the `export.xml` to handle exchange shipment. Prior to that when you would exchange an item in an order after customer return, it would create a new shipment but in the export.xml it would put the original item instead of the new one. I based my code on the `solidus_backend` view: https://github.com/solidusio/solidus/blob/master/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb