### PR TITLE
Fix factory girl dependency for Solidus < 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ else
 end
 
 group :test do
-  if branch < "v2.5"
+  if branch =< "v2.5"
     gem 'factory_bot', '4.10.0'
   else
     gem 'factory_bot', '> 4.10.0'

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'guard-rspec', require: false
 gem 'pry-rails', require: false
 gem 'codeclimate-test-reporter', group: :test, require: nil
 
-
 if branch == 'master' || branch >= "v2.0"
   gem "rails-controller-testing", group: :test
 else
@@ -15,7 +14,18 @@ else
   gem "rails_test_params_backport", group: :test
 end
 
-gem 'pg', '~> 0.21'
-gem 'mysql2', '~> 0.4.10'
+group :test do
+  if branch < "v2.5"
+    gem 'factory_bot', '4.10.0'
+  else
+    gem 'factory_bot', '> 4.10.0'
+  end
+end
+
+if ENV['DB'] == 'mysql'
+  gem 'mysql2', '~> 0.4.10'
+else
+  gem 'pg', '~> 0.21'
+end
 
 gemspec


### PR DESCRIPTION
We need to load a factory_bot version that has factory_girl in it
to support Solidus versions < 2.5

This change also includes conditional logic for the database
interface gems.